### PR TITLE
.net 8 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,13 @@ jobs:
         type: boolean
         default: false
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
     steps:
       - checkout
       - restore_cache:
           keys:
-            - dotnet-rd-client-lib-7.0
+            - dotnet-rd-client-lib-8.0
       - store_build_date
       - export_final_version:
           is_prerelease: << parameters.is_prerelease >>
@@ -80,7 +80,7 @@ jobs:
       - codecov/upload:
           validate: false
       - save_cache:
-          key: dotnet-rd-client-lib-7.0
+          key: dotnet-rd-client-lib-8.0
           paths:
             - .packages
       - run:
@@ -92,7 +92,7 @@ jobs:
             - lib
   publish_nuget_release:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:7.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
     steps:
       - attach_workspace:
           at: out

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Rent Dynamics
+Copyright (c) 2024 Rent Dynamics
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RentDynamics.RdClient.Tests/RentDynamics.RdClient.Tests.csproj
+++ b/RentDynamics.RdClient.Tests/RentDynamics.RdClient.Tests.csproj
@@ -1,28 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>11.0</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <AssemblyName>RentDynamics.RdClient.Tests</AssemblyName>
         <RootNamespace>RentDynamics.RdClient.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.2.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="6.8.0" />
-        <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions.Analyzers" Version="0.31.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RentDynamics.RdClient/RentDynamics.RdClient.csproj
+++ b/RentDynamics.RdClient/RentDynamics.RdClient.csproj
@@ -22,15 +22,26 @@
     <Import Project="../common.targets" />
 
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="FluentAssertions.Analyzers" Version="0.31.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
         <PackageReference Include="JsonNet.ContractResolvers" Version="2.0.0" />
-        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
+        <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="Polly" Version="7.2.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Polly" Version="8.3.1" />
         <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
     

--- a/RentDynamics.RdClient/RentDynamics.RdClient.csproj
+++ b/RentDynamics.RdClient/RentDynamics.RdClient.csproj
@@ -4,6 +4,7 @@
         <RootNamespace>RentDynamics.RdClient</RootNamespace>
         <AssemblyName>RentDynamics.RdClient</AssemblyName>
         <NoWarn>$(NoWarn);1591</NoWarn>
+        <IsPackable>true</IsPackable>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/common.props
+++ b/common.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <Title>RentDynamicsCS</Title>
         <Authors>Rent Dynamics</Authors>

--- a/version.md
+++ b/version.md
@@ -1,9 +1,14 @@
-0.6.0
+0.7.0
+
+### Changed
+* Upgrade project to .net 8
+
+## 0.6.0 -- 2023-07-18
 
 ### Changed
 * Upgrade project to .net 7
 
 ## 0.5.0 -- 2022-11-07
 
-## Features
+### Features
 * Add CreateEnqueueMessage


### PR DESCRIPTION
## PR Checklist
 * Which ticket is this associated with?
    * The initial upgrade is associated with #[CAR-2252](https://rentdynamics.atlassian.net/browse/CAR-2252)
 * Additional Notes
    * NOTE: I held off on upgrading the `Microsoft.AspNetCore.WebUtilities` NuGet package. It is currently on v2.2.0 and to upgrade we'd have to go to v8.0.x, which does not support the netstandard2.x. It only supports the target of .net8.
    * They have no immediate plans to enhance the NuGet package so that it conforms to the netstandard2.x as discussed on [this github issue](https://github.com/dotnet/aspnetcore/issues/50236)
    * So our options were:
      * Only support the target framework .net 8 (no longer support the netstandard2.x), which I think would have been completely fine. To my knowledge, we are the only consumers of this package.
      * Re-write a few helper functions that we use from that NuGet package
      * Keep the `Microsoft.AspNetCore.WebUtilities` version as it is. There is a reasonable chance that it will support the netstandard2.x in version 9 of .net. This is what I decided to do but if this ends up being a problem we can revisit this.
  * Related PR's
    * https://github.com/RentDynamics/pm-sync/pull/1871
    * https://github.com/RentDynamics/followup/pull/279
    * https://github.com/RentDynamics/lead-mgmt-api/pull/416
    * https://github.com/RentDynamics/callrouting/pull/417
    * https://github.com/RentDynamics/dotnetcore-shared/pull/257
    * https://github.com/RentDynamics/third-party-escalation-service/pull/70

## Dev Checklist
- [x] Verify you have incremented the version number in version.md (used in the CircleCI .yml file to generate the NuGet package with a new version number)
- [x] Verify unit tests


[CAR-2252]: https://rentdynamics.atlassian.net/browse/CAR-2252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ