### PR TITLE
Update sorting of json payload to match our javascript code so the nonce is calculated the same

### DIFF
--- a/RentDynamics.RdClient.Tests/JsonSortHelperTests.cs
+++ b/RentDynamics.RdClient.Tests/JsonSortHelperTests.cs
@@ -50,6 +50,21 @@ namespace RentDynamics.RdClient.Tests
         }
 
         [TestMethod]
+        public void ObjectProperties_ShouldBeSorted_ByAscii()
+        {
+            var unsortedDictionary = new Dictionary<string, object>
+            {
+                { "Id", 2 },
+                { "ID", 1 }
+            };
+
+            var jObject = JObject.FromObject(unsortedDictionary);
+            JsonSortHelper.Sort(jObject);
+
+            ShouldBeSorted(jObject);
+        }
+
+        [TestMethod]
         public void ObjectProperties_ShouldBeSorted_WhenObjectIsInsideArray()
         {
             var unsortedDictionary = new Dictionary<string, object>

--- a/RentDynamics.RdClient/JsonSortHelper.cs
+++ b/RentDynamics.RdClient/JsonSortHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -22,7 +23,7 @@ namespace RentDynamics.RdClient
                 jProperty.Remove();
             }
 
-            foreach (JProperty jProperty in properties.OrderBy(a => a.Name))
+            foreach (JProperty jProperty in properties.OrderBy(a => a.Name, StringComparer.Ordinal))
             {
                 jObject.Add(jProperty);
                 SortJProperty(jProperty);

--- a/version.md
+++ b/version.md
@@ -1,4 +1,9 @@
-0.7.0
+0.7.1
+
+### Changed
+* Update json sort helper to do an ordinal sort
+
+## 0.7.0 -- 2024-10-04
 
 ### Changed
 * Upgrade project to .net 8


### PR DESCRIPTION
## PR Checklist
 * Which ticket is this associated with?
    * Related to [CRM-3162](https://rentdynamics.atlassian.net/browse/CRM-3162)
 * Additional Notes
    * Our javascript calculates the nonce based on the .sort() function, which is an ascii sort. This change updates our .net projects, which are now sorting by unicode, to match the logic of our javascript projects.
```json
# javascript - ascii
{
  "processedAgentID":407,
  "processedAgentId":0
}

# .net - unicode (Before fix)
{
  "processedAgentId":0,
  "processedAgentID":407
}

# .net - ascii (After fix)
{
  "processedAgentID":407,
  "processedAgentId":0
}
```

## Dev Checklist
- [x] Verify you have incremented the version number in version.md (used in the CircleCI .yml file to generate the NuGet package with a new version number)
- [x] Verify unit tests


[CRM-3162]: https://rentdynamics.atlassian.net/browse/CRM-3162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ