### PR TITLE
Only read TextReader once

### DIFF
--- a/RentDynamics.RdClient/NonceCalculator.cs
+++ b/RentDynamics.RdClient/NonceCalculator.cs
@@ -23,23 +23,15 @@ namespace RentDynamics.RdClient
                 DateParseHandling = DateParseHandling.None //Prevent DateTime values from being converted to local timezone,
             };
 
-            try
+            var jToken = await JToken.LoadAsync(reader).ConfigureAwait(false);
+            if (jToken is JArray jArray)
             {
-                JObject jObject = await JObject.LoadAsync(reader).ConfigureAwait(false);
-                JsonSortHelper.Sort(jObject);
-                return jObject.ToString(Formatting.None);
-            }
-            catch (JsonReaderException ex) when (
-                ex.Message.IndexOf(
-                    "Current JsonReader item is not an object: StartArray.",
-                    StringComparison.OrdinalIgnoreCase
-                ) >= 0
-              )
-            {
-                JArray jArray = await JArray.LoadAsync(reader).ConfigureAwait(false);
                 JsonSortHelper.Sort(jArray);
                 return jArray.ToString(Formatting.None);
             }
+
+            JsonSortHelper.Sort(jToken);
+            return jToken.ToString(Formatting.None);
         }
 
         private static async Task<string?> PrepareBodyAsync(TextReader? dataReader)

--- a/RentDynamics.RdClient/NonceCalculator.cs
+++ b/RentDynamics.RdClient/NonceCalculator.cs
@@ -24,12 +24,6 @@ namespace RentDynamics.RdClient
             };
 
             var jToken = await JToken.LoadAsync(reader).ConfigureAwait(false);
-            if (jToken is JArray jArray)
-            {
-                JsonSortHelper.Sort(jArray);
-                return jArray.ToString(Formatting.None);
-            }
-
             JsonSortHelper.Sort(jToken);
             return jToken.ToString(Formatting.None);
         }

--- a/version.md
+++ b/version.md
@@ -1,4 +1,9 @@
-0.7.2
+0.7.3
+
+### Changed
+* Update json sort to only read once
+
+## 0.7.2 -- 2025-03-05
 
 ### Changed
 * Update json sort to handle arrays


### PR DESCRIPTION
## PR Checklist
 * Additional Notes
    * Update GetSortedJson to only read once to avoid possible exceptions when reading twice
    * This is a follow up to https://github.com/RentDynamics/rentdynamics-cs/pull/15

## Dev Checklist
- [x] Verify you have incremented the version number in version.md (used in the CircleCI .yml file to generate the NuGet package with a new version number)
- [x] Verify unit tests
