### PR TITLE
Error handling around JToken.LoadAsync

### DIFF
--- a/version.md
+++ b/version.md
@@ -1,4 +1,9 @@
-0.7.3
+0.7.4
+
+### Changed
+* Error handling around JToken.Load
+
+## 0.7.3 -- 2025-04-24
 
 ### Changed
 * Update json sort to only read once


### PR DESCRIPTION
## PR Checklist
 * Which ticket is this associated with?
    * Related to https://github.com/RentDynamics/followup/pull/293
 * Additional Notes
    * During the nonce calculation we attempt to load the request payload into a JToken. This can throw an exception on a null value or an empty string.
    * Ideally we'd inspect the content of the payload but this is not possible without reading from the Reader more than once. So instead we catch the JsonReaderException and return `null` which will be handled upstream.
    * Sample log:
<code>Newtonsoft.Json.JsonReaderException: Error reading JObject from JsonReader. Path '', line 0, position 0.    at Newtonsoft.Json.Linq.JObject.LoadAsync(JsonReader reader, JsonLoadSettings settings, CancellationToken cancellationToken)    at RentDynamics.RdClient.NonceCalculator.GetSortedJsonAsync(TextReader unsortedJsonReader)    at RentDynamics.RdClient.NonceCalculator.PrepareBodyAsync(TextReader dataReader)    at RentDynamics.RdClient.NonceCalculator.GetNonceAsync(String apiSecretKey, Int64 unixTimestampMilliseconds, String relativeUrl, TextReader dataReader)    at RentDynamics.Shared.Api.Security.Authorization.Nonce.RdNonceRequirementHandler.CalculateNonceAsync(HttpRequest request, String apiSecretKey, Int64 timestamp)    at RentDynamics.Shared.Api.Security.Authorization.Nonce.RdNonceRequirementHandler.CalculateAndValidateNonceAsync(String apiSecretKey, HttpContext httpContext, RdAuthorizationOptions options)    at CSharpFunctionalExtensions.ResultExtensions.TapError[T,E](Task`1 resultTask, Action`1 action)    at CSharpFunctionalExtensions.AsyncResultExtensionsLeftOperand.Tap[T,E](Task`1 resultTask, Action action)    at Microsoft.AspNetCore.Authorization.AuthorizationHandler`1.HandleAsync(AuthorizationHandlerContext context)    at Microsoft.AspNetCore.Authorization.DefaultAuthorizationService.AuthorizeAsync(ClaimsPrincipal user, Object resource, IEnumerable`1 requirements)    at Microsoft.AspNetCore.Authorization.Policy.PolicyEvaluator.AuthorizeAsync(AuthorizationPolicy policy, AuthenticateResult authenticationResult, HttpContext context, Object resource)    at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)    at RentDynamics.Shared.Api.HttpRequestBodyLoggerMiddleware.InvokeAsync(HttpContext context, ILogger`1 logger)    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)</code>

## Dev Checklist
- [x] Verify you have incremented the version number in version.md (used in the CircleCI .yml file to generate the NuGet package with a new version number)
- [x] Verify unit tests
