### PR TITLE
Convert empty JSON body to null

### DIFF
--- a/RentDynamics.RdClient.Tests/Handlers/RentDynamicsHttpClientAuthenticationHandlerTests.cs
+++ b/RentDynamics.RdClient.Tests/Handlers/RentDynamicsHttpClientAuthenticationHandlerTests.cs
@@ -105,5 +105,26 @@ namespace RentDynamics.RdClient.Tests.Handlers
 
             NonceCalculatorMock.Verify(c => c.GetNonceAsync(Options.ApiSecretKey, It.IsAny<long>(), urlWithQueryParams, It.IsNotNull<TextReader?>()));
         }
+
+        [TestMethod]
+        public void Test_ConvertNullTypeBodyToNull_EmptyBodyBecomesNull()
+        {
+            var body = "{}";
+
+            var result = NonceCalculator.ConvertNullTypeBodyToNull(body);
+
+            Assert.AreNotEqual(body, result);
+            Assert.AreEqual(result, null);
+        }
+
+        [TestMethod]
+        public void Test_ConvertNullTypeBodyToNull_BodyRemainsIntact()
+        {
+            var body = """{"Test":1}""";
+
+            var result = NonceCalculator.ConvertNullTypeBodyToNull(body);
+
+            Assert.AreEqual(result, body);
+        }
     }
 }

--- a/RentDynamics.RdClient/NonceCalculator.cs
+++ b/RentDynamics.RdClient/NonceCalculator.cs
@@ -44,7 +44,9 @@ namespace RentDynamics.RdClient
             if (dataReader == null) return null;
 
             string? sortedJson = await GetSortedJsonAsync(dataReader).ConfigureAwait(false);
-            return sortedJson?.Replace(" ", string.Empty);
+            string? sortedJsonWithoutWhitespace = sortedJson?.Replace(" ", string.Empty);
+
+            return ConvertNullTypeBodyToNull(sortedJsonWithoutWhitespace);
         }
 
         private static string ComputeHash(string apiSecretKey, string nonceString)
@@ -62,6 +64,11 @@ namespace RentDynamics.RdClient
             string nonceString = unixTimestampMilliseconds + relativeUrl + body;
 
             return ComputeHash(apiSecretKey, nonceString);
+        }
+
+        internal static string? ConvertNullTypeBodyToNull(string? body)
+        {
+            return body != "{}" ? body : null;
         }
     }
 }

--- a/version.md
+++ b/version.md
@@ -1,4 +1,9 @@
-0.7.4
+0.7.5
+
+### Changed
+* Convert empty JSON body to null
+
+## 0.7.4 -- 2025-04-28
 
 ### Changed
 * Error handling around JToken.Load


### PR DESCRIPTION
## PR Checklist
 * Which ticket is this associated with?
    * Closes #RP-15984
 * Additional Notes
    * When an empty JSON object is submitted as the body of a request, it gets stringified into `{}`. 
    * This is different behavior from the rentdynamics-py library, and causes nonce errors. 
    * This unifies the behavior of the two packages. 

## Dev Checklist
- [X] Verify you have incremented the version number in version.md (used in the CircleCI .yml file to generate the NuGet package with a new version number)
- [X] Verify unit tests
